### PR TITLE
Fixed function documenting error

### DIFF
--- a/docs/colors.md
+++ b/docs/colors.md
@@ -80,7 +80,7 @@ int myColor = Vx.getColorFromHex(hexCode);
 Color myColor = Vx.randomColor;
 ```
 
-> Get Random Non-Primary Color
+> Get Random Primary Color
 
 ```dart
 Color myColor = Vx.randomPrimaryColor;


### PR DESCRIPTION
The getter `Vx.randomPrimaryColor` was annotated as "Get random Non-Primary Color."